### PR TITLE
Add terraform default type patterns

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a problem with nvim-treesitter-context
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Before reporting make sure that both nvim-treesitter-context is
+        updated to the latest version.
+  - type: textarea
+    attributes:
+      label: "Description"
+      description: "A comprehensive description of the problem you are reporting."
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Neovim version"
+      description: |
+        Output of `nvim --version`
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Expected behavior"
+      description: "A description of the behavior you expected:"
+  - type: textarea
+    attributes:
+      label: "Actual behavior"
+      description: "Observed behavior (may optionally include images, or videos)."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+       label: "Minimal config"
+       description: >
+         Minimal(!) configuration necessary to reproduce the issue. Save this as
+         `minimal.lua`. If necessary, add plugins and config options from your
+         `init.lua` at the indicated lines.
+       render: Lua
+       value: |
+         local plugins = {
+           ts         = 'https://github.com/nvim-treesitter/nvim-treesitter',
+           ts_context = 'https://github.com/nvim-treesitter/nvim-treesitter-context',
+           -- ADD ADDITIONAL PLUGINS THAT ARE _NECESSARY_ TO REPRODUCE THE ISSUE
+         }
+
+         for name, url in pairs(plugins) do
+           local install_path = '/tmp/nvim/site/'..name
+           if vim.fn.isdirectory(install_path) == 0 then
+             vim.fn.system { 'git', 'clone', '--depth=1', url, install_path }
+           end
+           vim.o.runtimepath = install_path..','..vim.o.runtimepath
+         end
+
+         -- ADD INIT.LUA SETTINGS THAT IS _NECESSARY_ FOR REPRODUCING THE ISSUE
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+      description: "Steps to reproduce using the minimal config provided."
+      value: |
+        1. `nvim --clean -u minimal.lua`
+        2. ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        neovim_branch: ['v0.7.0']
+        neovim_branch: ['v0.8.2']
     runs-on: ubuntu-latest
     env:
       NEOVIM_BRANCH: ${{ matrix.neovim_branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,23 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
     strategy:
       fail-fast: true
       matrix:
         neovim_branch: ['v0.7.0']
-
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
     env:
       NEOVIM_BRANCH: ${{ matrix.neovim_branch }}
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup build dependencies
         run: |
@@ -59,7 +45,7 @@ jobs:
             unzip
 
       - name: Cache neovim
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: neovim-${{env.NEOVIM_BRANCH}}
           key: build-${{env.NEOVIM_BRANCH}}

--- a/Makefile
+++ b/Makefile
@@ -16,26 +16,21 @@ $(NEOVIM):
 nvim-treesitter:
 	git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter
 
-nvim-treesitter/parser/lua.so: nvim-treesitter $(NEOVIM)
+nvim-treesitter/parser/%.so: nvim-treesitter $(NEOVIM)
 	VIMRUNTIME=$(NEOVIM)/runtime $(NEOVIM)/build/bin/nvim \
 			   --headless \
 			   --clean \
 			   --cmd 'set rtp+=./nvim-treesitter' \
-			   -c "TSInstallSync lua" \
-			   -c "q"
-
-nvim-treesitter/parser/rust.so: nvim-treesitter $(NEOVIM)
-	VIMRUNTIME=$(NEOVIM)/runtime $(NEOVIM)/build/bin/nvim \
-			   --headless \
-			   --clean \
-			   --cmd 'set rtp+=./nvim-treesitter' \
-			   -c "TSInstallSync rust" \
+			   -c "TSInstallSync $*" \
 			   -c "q"
 
 export VIMRUNTIME=$(PWD)/$(NEOVIM)/runtime
 
 .PHONY: test
-test: $(NEOVIM) nvim-treesitter nvim-treesitter/parser/lua.so nvim-treesitter/parser/rust.so
+test: $(NEOVIM) nvim-treesitter \
+	nvim-treesitter/parser/lua.so \
+	nvim-treesitter/parser/rust.so \
+	nvim-treesitter/parser/typescript.so
 	$(NEOVIM)/.deps/usr/bin/busted \
 		-v \
 		--lazy \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ use 'nvim-treesitter/nvim-treesitter'
 use 'nvim-treesitter/nvim-treesitter-context'
 ```
 
-
 ## Screenshot
 
 ![theme](./static/demo.gif)
@@ -98,6 +97,9 @@ require'treesitter-context'.setup{
         json = {
             'pair',
         },
+        typescript = {
+            'export_statement',
+        },
         yaml = {
             'block_mapping_pair',
         },
@@ -135,6 +137,7 @@ context line numbers if `line_numbers` is set. Per default it links to `LineNr`.
 Use the highlight group `TreesitterContextBottom` to change the highlight of the
 last line of the context window. By default it links to `NONE`.
 However, you can use this to create a border by applying an underline highlight, e.g:
+
 ```vim
 hi TreesitterContextBottom gui=underline guisp=Grey
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ require'treesitter-context'.setup{
             'if',
             'switch',
             'case',
+            'interface',
+            'struct',
+            'enum',
         },
         -- Patterns for specific filetypes
         -- If a pattern is missing, *open a PR* so everyone can benefit.
@@ -68,10 +71,17 @@ require'treesitter-context'.setup{
             'subsection',
             'subsubsection',
         },
+        haskell = {
+            'adt'
+        },
         rust = {
             'impl_item',
-            'struct',
-            'enum',
+
+        },
+        terraform = {
+            'block',
+            'object_elem',
+            'attribute',
         },
         scala = {
             'object_definition',

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ implemented with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-trees
 
 ## Requirements
 
-Neovim >= v0.7.x
+Neovim >= v0.8.2
 
 Note: if you need support for Neovim 0.6.x please use the tag `compat/0.6`.
 
@@ -29,11 +29,166 @@ use 'nvim-treesitter/nvim-treesitter-context'
 
 ![theme](./static/demo.gif)
 
-### Notes
+## Supported languages
 
-This plugins uses the new neovim `WinScrolled` event when available to update its
-context window. Make sure to have a recent neovim build to get this behavior. The fallback
-behavior is to update its content on `CursorMoved`.
+  - [x] `bash`
+  - [x] `c`
+  - [x] `cpp`
+  - [x] `typescript`
+  - [x] `rust`
+  - [x] `json`
+  - [x] `lua`
+  - [x] `markdown`
+  - [x] `python`
+  - [x] `yaml`
+  - [x] `php`
+  - [x] `scala`
+  - [x] `teal`
+  - [x] `toml`
+  - [x] `vim`
+  - [ ] `ada`
+  - [ ] `agda`
+  - [ ] `arduino`
+  - [ ] `astro`
+  - [ ] `beancount`
+  - [ ] `bibtex`
+  - [ ] `bicep`
+  - [ ] `blueprint`
+  - [ ] `c_sharp`
+  - [ ] `capnp`
+  - [ ] `chatito`
+  - [ ] `clojure`
+  - [ ] `cmake`
+  - [ ] `commonlisp`
+  - [ ] `cooklang`
+  - [ ] `cpon`
+  - [ ] `css`
+  - [ ] `cuda`
+  - [ ] `d`
+  - [ ] `dart`
+  - [ ] `devicetree`
+  - [ ] `dhall`
+  - [ ] `dockerfile`
+  - [ ] `dot`
+  - [ ] `ebnf`
+  - [ ] `ecma`
+  - [ ] `eex`
+  - [ ] `elixir`
+  - [ ] `elm`
+  - [ ] `elsa`
+  - [ ] `elvish`
+  - [ ] `embedded_template`
+  - [ ] `erlang`
+  - [ ] `fennel`
+  - [ ] `fish`
+  - [ ] `foam`
+  - [ ] `fsh`
+  - [ ] `func`
+  - [ ] `fusion`
+  - [ ] `gdscript`
+  - [ ] `git_rebase`
+  - [ ] `gleam`
+  - [ ] `glimmer`
+  - [ ] `glsl`
+  - [ ] `go`
+  - [ ] `godot_resource`
+  - [ ] `gomod`
+  - [ ] `gosum`
+  - [ ] `gowork`
+  - [ ] `graphql`
+  - [ ] `hack`
+  - [ ] `haskell`
+  - [ ] `hcl`
+  - [ ] `heex`
+  - [ ] `hjson`
+  - [ ] `hlsl`
+  - [ ] `hocon`
+  - [ ] `html`
+  - [ ] `html_tags`
+  - [ ] `htmldjango`
+  - [ ] `http`
+  - [ ] `ini`
+  - [ ] `java`
+  - [ ] `javascript`
+  - [ ] `jq`
+  - [ ] `jsdoc`
+  - [ ] `json5`
+  - [ ] `jsonc`
+  - [ ] `jsonnet`
+  - [ ] `jsx`
+  - [ ] `julia`
+  - [ ] `kdl`
+  - [ ] `kotlin`
+  - [ ] `lalrpop`
+  - [ ] `latex`
+  - [ ] `ledger`
+  - [ ] `llvm`
+  - [ ] `m68k`
+  - [ ] `matlab`
+  - [ ] `menhir`
+  - [ ] `mermaid`
+  - [ ] `meson`
+  - [ ] `nickel`
+  - [ ] `nix`
+  - [ ] `ocaml`
+  - [ ] `ocaml_interface`
+  - [ ] `ocamllex`
+  - [ ] `pascal`
+  - [ ] `perl`
+  - [ ] `phpdoc`
+  - [ ] `pioasm`
+  - [ ] `po`
+  - [ ] `poe_filter`
+  - [ ] `prisma`
+  - [ ] `proto`
+  - [ ] `prql`
+  - [ ] `pug`
+  - [ ] `ql`
+  - [ ] `qmldir`
+  - [ ] `qmljs`
+  - [ ] `query`
+  - [ ] `r`
+  - [ ] `racket`
+  - [ ] `rasi`
+  - [ ] `rego`
+  - [ ] `rnoweb`
+  - [ ] `ron`
+  - [ ] `rst`
+  - [ ] `ruby`
+  - [ ] `scheme`
+  - [ ] `scss`
+  - [ ] `slint`
+  - [ ] `smali`
+  - [ ] `smithy`
+  - [ ] `solidity`
+  - [ ] `sparql`
+  - [ ] `sql`
+  - [ ] `starlark`
+  - [ ] `supercollider`
+  - [ ] `surface`
+  - [ ] `svelte`
+  - [ ] `swift`
+  - [ ] `sxhkdrc`
+  - [ ] `t32`
+  - [ ] `terraform`
+  - [ ] `thrift`
+  - [ ] `tiger`
+  - [ ] `tlaplus`
+  - [ ] `todotxt`
+  - [ ] `tsx`
+  - [ ] `turtle`
+  - [ ] `twig`
+  - [ ] `ungrammar`
+  - [ ] `v`
+  - [ ] `vala`
+  - [ ] `verilog`
+  - [ ] `vhs`
+  - [ ] `vue`
+  - [ ] `wgsl`
+  - [ ] `wgsl_bevy`
+  - [ ] `yang`
+  - [ ] `yuck`
+  - [ ] `zig`
 
 ## Configuration
 
@@ -41,94 +196,17 @@ behavior is to update its content on `CursorMoved`.
 
 ```lua
 require'treesitter-context'.setup{
-    enable = true, -- Enable this plugin (Can be enabled/disabled later via commands)
-    max_lines = 0, -- How many lines the window should span. Values <= 0 mean no limit.
-    trim_scope = 'outer', -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
-    min_window_height = 0, -- Minimum editor window height to enable context. Values <= 0 mean no limit.
-    patterns = { -- Match patterns for TS nodes. These get wrapped to match at word boundaries.
-        -- For all filetypes
-        -- Note that setting an entry here replaces all other patterns for this entry.
-        -- By setting the 'default' entry below, you can control which nodes you want to
-        -- appear in the context window.
-        default = {
-            'class',
-            'function',
-            'method',
-            'for',
-            'while',
-            'if',
-            'switch',
-            'case',
-            'interface',
-            'struct',
-            'enum',
-        },
-        -- Patterns for specific filetypes
-        -- If a pattern is missing, *open a PR* so everyone can benefit.
-        tex = {
-            'chapter',
-            'section',
-            'subsection',
-            'subsubsection',
-        },
-        haskell = {
-            'adt'
-        },
-        rust = {
-            'impl_item',
-
-        },
-        terraform = {
-            'block',
-            'object_elem',
-            'attribute',
-        },
-        scala = {
-            'object_definition',
-        },
-        vhdl = {
-            'process_statement',
-            'architecture_body',
-            'entity_declaration',
-        },
-        markdown = {
-            'section',
-        },
-        elixir = {
-            'anonymous_function',
-            'arguments',
-            'block',
-            'do_block',
-            'list',
-            'map',
-            'tuple',
-            'quoted_content',
-        },
-        json = {
-            'pair',
-        },
-        typescript = {
-            'export_statement',
-        },
-        yaml = {
-            'block_mapping_pair',
-        },
-    },
-    exact_patterns = {
-        -- Example for a specific filetype with Lua patterns
-        -- Treat patterns.rust as a Lua pattern (i.e "^impl_item$" will
-        -- exactly match "impl_item" only)
-        -- rust = true,
-    },
-
-    -- [!] The options below are exposed but shouldn't require your attention,
-    --     you can safely ignore them.
-
-    zindex = 20, -- The Z-index of the context window
-    mode = 'cursor',  -- Line used to calculate context. Choices: 'cursor', 'topline'
-    -- Separator between context and content. Should be a single character string, like '-'.
-    -- When separator is set, the context will only show up when there are at least 2 lines above cursorline.
-    separator = nil,
+  enable = true, -- Enable this plugin (Can be enabled/disabled later via commands)
+  max_lines = 0, -- How many lines the window should span. Values <= 0 mean no limit.
+  min_window_height = 0, -- Minimum editor window height to enable context. Values <= 0 mean no limit.
+  line_numbers = true,
+  multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
+  trim_scope = 'outer', -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
+  mode = 'cursor',  -- Line used to calculate context. Choices: 'cursor', 'topline'
+  -- Separator between context and content. Should be a single character string, like '-'.
+  -- When separator is set, the context will only show up when there are at least 2 lines above cursorline.
+  separator = nil,
+  zindex = 20, -- The Z-index of the context window
 }
 ```
 
@@ -151,3 +229,38 @@ However, you can use this to create a border by applying an underline highlight,
 ```vim
 hi TreesitterContextBottom gui=underline guisp=Grey
 ```
+
+## Adding support for other languages
+
+To add support for another language, simply add a `context.scm` file under
+`queries/[LANG]`.
+
+Queries specify the `@context` capture which specifies the first line of a node
+will be used for the context.
+
+Here is a basic example for C:
+
+```query
+(function_definition) @context
+(for_statement) @context
+(if_statement) @context
+(while_statement) @context
+(do_statement) @context
+```
+
+You can easily look at a node names of a tree using `InspectTree` in Nvim 0.9.
+
+Additionally an optional `@context.end` capture can also be specified. When
+provided, the text from the start of the `@context` capture to the start of
+`@context.end` capture (exclusive) will be used for the context and joined into
+a single line.
+
+Here's what that looks like for C:
+
+```query
+(if_statement consequence: (_ (_) @context.end)) @context
+```
+
+This query specifies that everything from the `if` keyword up-to the first
+statement (exclusive) should be used for the context. This is useful when an
+if-statement spans multiple lines.

--- a/README.md
+++ b/README.md
@@ -131,3 +131,10 @@ context. Per default it links to `NormalFloat`.
 
 Use the highlight group `TreesitterContextLineNumber` to change the colors of the
 context line numbers if `line_numbers` is set. Per default it links to `LineNr`.
+
+Use the highlight group `TreesitterContextBottom` to change the highlight of the
+last line of the context window. By default it links to `NONE`.
+However, you can use this to create a border by applying an underline highlight, e.g:
+```vim
+hi TreesitterContextBottom gui=underline guisp=Grey
+```

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -748,7 +748,7 @@ local update = throttle_fn(function()
     previous_nodes = context
 
     if api.nvim_win_get_height(0) < config.min_window_height then
-      M.close()
+      close()
       return
     end
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -531,6 +531,7 @@ local function set_lines(bufnr, lines)
 
   if redraw then
     api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    api.nvim_buf_set_option(bufnr, 'modified', false)
   end
 
   return redraw

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -653,57 +653,6 @@ local function normalize_node(node)
   return node
 end
 
-local virt_text_ns = api.nvim_create_namespace("nvim-treesitter-context-virt-text")
----Render virtual text in the context buffer, includes extmarks and diagnostics
----@param cbufnr integer buf number of the context buffer
----@param extmarks table result of `clone_extmarks_into()`
----@param diagnostics table result of `clone_diagnostics_into()`
-local function render_virtual_text(cbufnr, extmarks, diagnostics)
-  api.nvim_buf_clear_namespace(cbufnr, virt_text_ns, 0, -1)
-
-  local len = api.nvim_buf_line_count(cbufnr)
-  for line = 0, len do
-    for _, m_info in ipairs(extmarks[line] or {}) do
-      api.nvim_buf_set_extmark(cbufnr, virt_text_ns, line, m_info.col, m_info.opts)
-    end
-  end
-
-  -- this is a hack b/c the diagnostic virtual text isn't accessible through nvim_buf_get_extmarks
-  vim.diagnostic.handlers.virtual_text.hide(virt_text_ns, cbufnr)
-  vim.diagnostic.handlers.virtual_text.show(virt_text_ns, cbufnr, diagnostics)
-end
-
----Clone existing, namespaced, extmarks present in the given range, and insert them into extmarks
----@param extmarks table from line number to list of extmarks on that line
----@param bufnr integer buffer number we're searching for ext marks
----@param range table<integer> { start_row, start_col, end_row, end_col }
----@param context_line_num integer the line in the context that this should be associated with
-local function clone_extmarks_into(extmarks, bufnr, range, context_line_num)
-  for _, n in pairs(api.nvim_get_namespaces()) do
-    local found_extmarks = api.nvim_buf_get_extmarks(bufnr, n, { range[1], range[2] }, { range[3], range[4] },
-      { details = true })
-    for _, e in pairs(found_extmarks) do
-      if extmarks[context_line_num] == nil then
-        extmarks[context_line_num] = {}
-      end
-      table.insert(extmarks[context_line_num], { col = e[3], opts = e[4] })
-    end
-  end
-end
-
----Clone existing diagnostic info from the given line
----@param diagnostics table from line number to list of diagnostics on that line
----@param bufnr integer buffer to find diagnostics in
----@param line integer line to copy diagnostics from
----@param context_line_num integer corresponding context buf line number
-local function clone_diagnostics_into(diagnostics, bufnr, line, context_line_num)
-  for _, d in ipairs(vim.diagnostic.get(bufnr, { lnum = line })) do
-    local copy = vim.deepcopy(d)
-    copy.lnum = context_line_num
-    table.insert(diagnostics, copy)
-  end
-end
-
 local function open(ctx_nodes)
   local bufnr = api.nvim_get_current_buf()
 
@@ -728,10 +677,8 @@ local function open(ctx_nodes)
   local context_text = {}
   local lno_text = {}
   local contexts = {}
-  local extmarks = {}
-  local diagnostics = {}
 
-  for idx, node in ipairs(ctx_nodes) do
+  for _, node in ipairs(ctx_nodes) do
     node = normalize_node(node)
 
     local lines, range = get_text_for_node(node)
@@ -755,18 +702,14 @@ local function open(ctx_nodes)
       line_num = ctx_line_num
     end
     table.insert(lno_text, build_lno_str(line_num, gutter_width-1))
-    clone_extmarks_into(extmarks, bufnr, range, idx - 1)
-    clone_diagnostics_into(diagnostics, bufnr, ctx_line_num - 1, idx - 1)
   end
 
   set_lines(gbufnr, lno_text)
-  local skip_highlights = not set_lines(ctx_bufnr, context_text)
-
-  render_virtual_text(ctx_bufnr, extmarks, diagnostics)
-
-  if skip_highlights then
+  if not set_lines(ctx_bufnr, context_text) then
+    -- Context didn't change, can return here
     return
   end
+
 
   highlight_contexts(bufnr, ctx_bufnr, contexts)
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -115,6 +115,9 @@ local DEFAULT_TYPE_PATTERNS = {
   markdown = {
     'section',
   },
+  python = {
+    'with_statement',
+  },
   rust = {
     'impl_item',
   },

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -692,6 +692,9 @@ local function open(ctx_nodes)
 
 
   highlight_contexts(bufnr, ctx_bufnr, contexts)
+
+  api.nvim_buf_set_extmark(ctx_bufnr, ns, #lno_text-1, 0, {end_line=#lno_text, hl_group='TreesitterContextBottom', hl_eol=true})
+  api.nvim_buf_set_extmark(gbufnr, ns, #context_text-1, 0, {end_line=#context_text, hl_group='TreesitterContextBottom', hl_eol=true})
 end
 
 local function calc_max_lines(config_max)
@@ -826,8 +829,9 @@ command('TSContextEnable' , M.enable , {})
 command('TSContextDisable', M.disable, {})
 command('TSContextToggle' , M.toggle , {})
 
-api.nvim_set_hl(0, 'TreesitterContext'          , {link = 'NormalFloat', default = true})
-api.nvim_set_hl(0, 'TreesitterContextLineNumber', {link = 'LineNr'     , default = true})
+api.nvim_set_hl(0, 'TreesitterContext',           {link = 'NormalFloat', default = true})
+api.nvim_set_hl(0, 'TreesitterContextLineNumber', {link = 'LineNr',      default = true})
+api.nvim_set_hl(0, 'TreesitterContextBottom',     {link = 'NONE',        default = true})
 
 -- Setup with default options if user didn't call setup()
 autocmd_for_group('treesitter_context')('VimEnter', function()

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -93,6 +93,8 @@ local DEFAULT_TYPE_PATTERNS = {
     'switch',
     'case',
     'interface',
+    'struct',
+    'enum',
   },
   tex = {
     'chapter',
@@ -105,8 +107,7 @@ local DEFAULT_TYPE_PATTERNS = {
   },
   rust = {
     'impl_item',
-    'struct',
-    'enum',
+ 
   },
   terraform = {
     'block',

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -138,6 +138,9 @@ local DEFAULT_TYPE_PATTERNS = {
   json = {
     'pair',
   },
+  typescript = {
+    'export_statement',
+  },
   yaml = {
     'block_mapping_pair',
   },

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -96,39 +96,6 @@ local DEFAULT_TYPE_PATTERNS = {
     'struct',
     'enum',
   },
-  tex = {
-    'chapter',
-    'section',
-    'subsection',
-    'subsubsection',
-  },
-  haskell = {
-    'adt'
-  },
-  rust = {
-    'impl_item',
- 
-  },
-  terraform = {
-    'block',
-    'object_elem',
-    'attribute',
-  },
-  scala = {
-    'object_definition',
-  },
-  verilog = {
-    'always_construct',
-    'statement_or_null',
-  },
-  vhdl = {
-    'process_statement',
-    'architecture_body',
-    'entity_declaration',
-  },
-  markdown = {
-    'section',
-  },
   elixir = {
     'anonymous_function',
     'arguments',
@@ -139,11 +106,43 @@ local DEFAULT_TYPE_PATTERNS = {
     'tuple',
     'quoted_content',
   },
+  haskell = {
+    'adt'
+  },
   json = {
     'pair',
   },
+  markdown = {
+    'section',
+  },
+  rust = {
+    'impl_item',
+  },
+  scala = {
+    'object_definition',
+  },
+  terraform = {
+    'block',
+    'object_elem',
+    'attribute',
+  },
+  tex = {
+    'chapter',
+    'section',
+    'subsection',
+    'subsubsection',
+  },
   typescript = {
     'export_statement',
+  },
+  verilog = {
+    'always_construct',
+    'statement_or_null',
+  },
+  vhdl = {
+    'process_statement',
+    'architecture_body',
+    'entity_declaration',
   },
   yaml = {
     'block_mapping_pair',

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -117,6 +117,10 @@ local DEFAULT_TYPE_PATTERNS = {
   scala = {
     'object_definition',
   },
+  verilog = {
+    'always_construct',
+    'statement_or_null',
+  },
   vhdl = {
     'process_statement',
     'architecture_body',

--- a/queries/bash/context.scm
+++ b/queries/bash/context.scm
@@ -1,0 +1,6 @@
+
+([
+  (for_statement)
+  (function_definition)
+  (if_statement)
+] @context)

--- a/queries/c/context.scm
+++ b/queries/c/context.scm
@@ -1,0 +1,28 @@
+
+(function_definition
+  body: (_ (_) @context.end)
+) @context
+
+(for_statement
+  (compound_statement) @context.end
+) @context
+
+(if_statement
+  consequence: (_ (_) @context.end)
+) @context
+
+(while_statement
+  body: (_ (_) @context.end)
+) @context
+
+(do_statement
+  body: (_ (_) @context.end)
+) @context
+
+(struct_specifier
+  body: (_ (_) @context.end)
+) @context
+
+(enum_specifier
+  body: (_ (_) @context.end)
+) @context

--- a/queries/cpp/context.scm
+++ b/queries/cpp/context.scm
@@ -1,0 +1,5 @@
+; inherits: c
+
+(class_specifier
+  body: (_ (_) @context.end)
+) @context

--- a/queries/json/context.scm
+++ b/queries/json/context.scm
@@ -1,0 +1,5 @@
+
+([
+  (object)
+  (pair)
+] @context)

--- a/queries/lua/context.scm
+++ b/queries/lua/context.scm
@@ -1,0 +1,27 @@
+(for_statement
+  body: (_) @context.end
+) @context
+
+(while_statement
+  body: (_) @context.end
+) @context
+
+(do_statement
+  body: (_) @context.end
+) @context
+
+(function_definition
+  body: (_) @context.end
+) @context
+
+(table_constructor
+  (_) @context.end
+) @context
+
+(function_declaration
+  parameters: (_) @context.final
+) @context
+
+(if_statement
+  consequence: (_) @context.end
+) @context

--- a/queries/markdown/context.scm
+++ b/queries/markdown/context.scm
@@ -1,0 +1,2 @@
+
+((section) @context)

--- a/queries/php/context.scm
+++ b/queries/php/context.scm
@@ -1,0 +1,28 @@
+
+(function_definition
+  body: (_ (_) @context.end)
+) @context
+
+(while_statement
+  body: (_ (_) @context.end)
+) @context
+
+(if_statement
+  body: (_ (_) @context.end)
+) @context
+
+(do_statement
+  body: (_ (_) @context.end)
+) @context
+
+(foreach_statement
+  body: (_ (_) @context.end)
+) @context
+
+(class_declaration
+  body: (_ (_) @context.end)
+) @context
+
+(for_statement
+  (compound_statement (_) @context.end)
+) @context

--- a/queries/python/context.scm
+++ b/queries/python/context.scm
@@ -1,0 +1,47 @@
+(class_definition
+  body: (_) @context.end
+) @context
+
+(function_definition
+  body: (_) @context.end
+) @context
+
+(try_statement
+  body: (_) @context.end
+) @context
+
+(with_statement
+  body: (_) @context.end
+) @context
+
+(if_statement
+  consequence: (_) @context.end
+) @context
+
+(elif_clause
+  consequence: (_) @context.end
+) @context
+
+(case_clause
+  consequence: (_) @context.end
+) @context
+
+(while_statement
+  body: (_) @context.end
+) @context
+
+(except_clause
+  (block) @context.end
+) @context
+
+(match_statement
+  alternative: (_) @context.end
+) @context
+
+([
+  (for_statement)
+  (finally_clause)
+  (else_clause)
+  (pair)
+  (expression_statement)
+] @context)

--- a/queries/rust/context.scm
+++ b/queries/rust/context.scm
@@ -1,0 +1,29 @@
+
+(for_expression
+  body: (_ (_) @context.end)
+) @context
+
+(if_expression
+  consequence: (_ (_) @context.end)
+) @context
+
+(function_item
+  body: (_ (_) @context.end)
+) @context
+
+(impl_item
+  type: (_) @context.final
+) @context
+
+(struct_item
+  body: (_ (_) @context.end)
+) @context
+
+([
+  (mod_item)
+  (enum_item)
+  (closure_expression)
+  (expression_statement)
+  (loop_expression)
+  (match_expression)
+] @context)

--- a/queries/scala/context.scm
+++ b/queries/scala/context.scm
@@ -1,0 +1,28 @@
+
+(function_definition
+  body: (_ (_) @context.end)
+) @context
+
+(class_definition
+  body: (_ (_) @context.end)
+) @context
+
+(object_definition
+  body: (_ (_) @context.end)
+) @context
+
+(case_clause
+  body: (_ (_) @context.end)
+) @context
+
+(match_expression
+  body: (_ (_) @context.end)
+) @context
+
+(call_expression
+  arguments: (_ (_) @context.end)
+) @context
+
+(if_expression
+  consequence: (_ (_) @context.end)
+) @context

--- a/queries/teal/context.scm
+++ b/queries/teal/context.scm
@@ -1,0 +1,28 @@
+
+(while_statement) @context
+
+(generic_for_statement
+  body: (_ (_) @context.end)
+) @context
+
+(function_statement
+  body: (_) @context.end
+) @context
+
+(anon_function
+  body: (_) @context.end
+) @context
+
+(if_statement
+  condition: (_)
+  (_) @context.end
+) @context
+
+(elseif_block
+  condition: (_)
+  (_) @context.end
+) @context
+
+(record_declaration
+  record_body: (_) @context.end
+) @context

--- a/queries/toml/context.scm
+++ b/queries/toml/context.scm
@@ -1,0 +1,5 @@
+
+([
+  (table)
+  (pair)
+] @context)

--- a/queries/typescript/context.scm
+++ b/queries/typescript/context.scm
@@ -1,0 +1,23 @@
+(interface_declaration
+  body: (_ (_) @context.end)
+) @context
+
+(class_declaration
+  body: (_ (_) @context.end)
+) @context
+
+(method_definition
+  body: (_ (_) @context.end)
+) @context
+
+(for_statement
+  body: (_ (_) @context.end)
+) @context
+
+(function_declaration
+  body: (_ (_) @context.end)
+) @context
+
+(if_statement
+  consequence: (_ (_) @context.end)
+) @context

--- a/queries/vim/context.scm
+++ b/queries/vim/context.scm
@@ -1,0 +1,36 @@
+
+(if_statement
+  (body) @context.end
+) @context
+
+(elseif_statement
+  (body) @context.end
+) @context
+
+(else_statement
+  (body) @context.end
+) @context
+
+(function_definition
+  (body) @context.end
+) @context
+
+(while_loop
+  (body) @context.end
+) @context
+
+(for_loop
+  (body) @context.end
+) @context
+
+(try_statement
+  (body) @context.end
+) @context
+
+(catch_statement
+  (body) @context.end
+) @context
+
+(finally_statement
+  (body) @context.end
+) @context

--- a/queries/yaml/context.scm
+++ b/queries/yaml/context.scm
@@ -1,0 +1,5 @@
+([
+  (block_mapping)
+  (block_mapping_pair)
+  (block_sequence_item)
+] @context)

--- a/test/test.c
+++ b/test/test.c
@@ -1,0 +1,76 @@
+struct Bert {
+    int *f1;
+    // comment
+    int *f2;
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+};
+
+typedef enum {
+  E1,
+  E2,
+  E3
+  // comment
+  // comment
+  // comment
+  // comment
+  // comment
+  // comment
+} Myenum;
+
+int main(int arg1,
+         char **arg2,
+         char **arg3
+         )
+{
+
+  if (arg1 == 4
+      && arg2 == arg3) {
+
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    for (int i = 0; i < arg1; i++) {
+      // comment
+      // comment
+      // comment
+      // comment
+      while (1) {
+        // comment
+        // comment
+        // comment
+        // comment
+        // comment
+      }
+
+      do {
+        // comment
+        // comment
+        // comment
+        // comment
+        // comment
+
+      } while (1);
+      // comment
+      // comment
+      // comment
+      // comment
+      // comment
+    }
+
+  }
+}

--- a/test/test.php
+++ b/test/test.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * comment
+ */
+function foo($a, $b) {
+  //loop, between low & high
+  while ($a <= $b) {
+    // comment
+    $index = $low + floor(($high - $low) * $delta);
+    // comment
+    $indexValue = $a;
+    if ($indexValue === $a) {
+      // comment
+
+
+      $position = $index;
+      return (int) $position;
+    }
+    if ($indexValue < $key) {
+      // comment
+
+      $low = $index + 1;
+    }
+    if ($indexValue > $key) {
+      // comment
+      do {
+        // comment
+        echo "The number is: $x <br>";
+        $x++;
+
+
+
+
+      } while ($x <= 5);
+
+      for ($x = 0; $x <= 10; $x++) {
+        echo "The number is: $x <br>";
+
+
+
+
+
+
+
+
+
+
+
+      }
+
+
+
+      foreach ($colors as $value) {
+        echo "$value <br>";
+
+
+
+
+
+
+      }
+
+      $high = $index - 1;
+    }
+  }
+
+
+
+  //when key not found in array or array not sorted
+  return null;
+}
+
+class Fruit {
+
+
+
+
+ // comment
+
+
+
+
+}

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,10 +1,26 @@
 impl Foo {
 
+
+
+
     fn bar(&self) {
+
+
+
+
+
         if condition {
 
 
+
+
+
+
             for i in 0..100 {
+
+
+
+                // comment
 
 
             }
@@ -13,5 +29,13 @@ impl Foo {
 }
 
 struct Foo {
+
+    active: bool,
+
+    username: String,
+
+    email: String,
+
+    sign_in_count: u64,
 
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,47 @@
+interface User {
+  name: string;
+
+
+
+  id: number;
+
+
+
+
+}
+ 
+class UserAccount {
+  name: string;
+  id: number;
+
+
+
+ 
+  constructor(name: string, id: number) {
+    this.name = name;
+    this.id = id;
+
+    for (let i = 0; i < 3; i++) {
+        console.log("hello");
+
+
+
+    }
+
+
+
+
+  }
+}
+
+
+function wrapInArray(obj: string | string[]) {
+  if (typeof obj === "string") {
+    return [obj];
+
+
+
+
+  }
+  return obj;
+}

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -3,15 +3,16 @@ local Screen = require('test.functional.ui.screen')
 
 local clear    = helpers.clear
 local exec_lua = helpers.exec_lua
-local eq       = helpers.eq
 local cmd      = helpers.command
 local feed     = helpers.feed
 
 describe('ts_context', function()
   local screen
 
-  setup(function()
+  before_each(function()
+    clear()
     screen = Screen.new(30, 16)
+    screen:attach()
     screen:set_default_attr_ids({
       [1] = {foreground = Screen.colors.Brown, background = Screen.colors.LightMagenta, bold = true};
       [2] = {background = Screen.colors.LightMagenta};
@@ -19,12 +20,13 @@ describe('ts_context', function()
       [4] = {bold = true, foreground = Screen.colors.Brown};
       [5] = {foreground = Screen.colors.DarkCyan};
       [6] = {bold = true, foreground = Screen.colors.Blue};
+      [7] = {foreground = Screen.colors.SeaGreen, background = Screen.colors.LightMagenta, bold = true};
+      [8] = {foreground = Screen.colors.Blue};
+      [9] = {bold = true, foreground = Screen.colors.SeaGreen};
+      [10] = {foreground = Screen.colors.Fuchsia, background = Screen.colors.LightMagenta};
+      [11] = {foreground = Screen.colors.Fuchsia};
+      [12] = {foreground = tonumber('0x6a0dad'), background = Screen.colors.LightMagenta};
     })
-  end)
-
-  before_each(function()
-    clear()
-    screen:attach()
     cmd [[set runtimepath+=.,./nvim-treesitter]]
     cmd [[let $XDG_CACHE_HOME='scratch/cache']]
     cmd [[set packpath=]]
@@ -88,99 +90,191 @@ describe('ts_context', function()
     ]]}
   end)
 
-  it('edit a file in topline mode', function()
-    exec_lua[[require'treesitter-context'.setup{
-      mode = 'topline',
-      max_lines = 2,
-    }]]
-    cmd('edit test/nested_file.rs')
-    feed'L'
-    feed'<C-e>'
-    -- screen:snapshot_util()
-    screen:expect{grid=[[
-      {1:impl}{2: Foo {                    }|
-          {4:fn} {5:bar}({7:&}{8:self}) {           |
-              {4:if} condition {        |
-                                    |
-                                    |
-                  {4:for} i {4:in} {8:0}..{8:100} { |
-                                    |
-                                    |
-                  }                 |
-              }                     |
-          }                         |
-      }                             |
-                                    |
-      {4:^struct} {5:Foo} {                  |
-                                    |
-                                    |
-    ]], attr_ids={
-      [1] = {foreground = Screen.colors.Brown, background = Screen.colors.Plum1, bold = true};
-      [2] = {background = Screen.colors.Plum1};
-      [3] = {foreground = Screen.colors.Cyan4, background = Screen.colors.Plum1};
-      [4] = {bold = true, foreground = Screen.colors.Brown};
-      [5] = {foreground = Screen.colors.Cyan4};
-      [6] = {bold = true, foreground = Screen.colors.Blue1};
-      [7] = {bold = true, foreground = Screen.colors.SeaGreen4};
-      [8] = {foreground = Screen.colors.Fuchsia};
-    }}
+  describe('language:', function()
+    before_each(function()
+      exec_lua[[require'treesitter-context'.setup{
+        mode = 'topline',
+      }]]
+      cmd'set scrolloff=5'
+      cmd'set nowrap'
+    end)
 
-    feed'<C-e>'
-    screen:expect{grid=[[
-      {2:    }{1:fn}{2: }{3:bar}{2:(}{7:&}{8:self}{2:)             }|
-      {2:        }{1:if}{2: condition {        }|
-                                    |
-                                    |
-                  {4:for} i {4:in} {9:0}..{9:100} { |
-                                    |
-                                    |
-                  }                 |
-              }                     |
-          }                         |
-      }                             |
-                                    |
-      {4:^struct} {5:Foo} {                  |
-                                    |
-      }                             |
-                                    |
-    ]], attr_ids={
-      [1] = {foreground = Screen.colors.Brown, bold = true, background = Screen.colors.LightMagenta};
-      [2] = {background = Screen.colors.LightMagenta};
-      [3] = {background = Screen.colors.LightMagenta, foreground = Screen.colors.Cyan4};
-      [4] = {foreground = Screen.colors.Brown, bold = true};
-      [5] = {foreground = Screen.colors.Cyan4};
-      [6] = {foreground = Screen.colors.Blue1, bold = true};
-      [7] = {foreground = Screen.colors.SeaGreen4, bold = true, background = Screen.colors.LightMagenta};
-      [8] = {background = Screen.colors.LightMagenta, foreground = Screen.colors.Magenta1};
-      [9] = {foreground = Screen.colors.Magenta1};
-    }}
+    it('rust', function()
+      cmd('edit test/test.rs')
+      feed'20<C-e>'
 
-    feed'3<C-e>'
-    screen:expect{grid=[[
-      {2:        }{1:if}{2: condition {        }|
-      {2:            }{1:for}{2: i }{1:in}{2: }{7:0}{2:..}{7:100}{2: { }|
-                                    |
-                                    |
-                  }                 |
-              }                     |
-          }                         |
-      }                             |
-                                    |
-      {4:^struct} {5:Foo} {                  |
-                                    |
-      }                             |
-      {6:~                             }|
-      {6:~                             }|
-      {6:~                             }|
-                                    |
-    ]], attr_ids={
-      [1] = {background = Screen.colors.Plum1, bold = true, foreground = Screen.colors.Brown};
-      [2] = {background = Screen.colors.Plum1};
-      [3] = {background = Screen.colors.Plum1, foreground = Screen.colors.Cyan4};
-      [4] = {foreground = Screen.colors.Brown, bold = true};
-      [5] = {foreground = Screen.colors.Cyan4};
-      [6] = {foreground = Screen.colors.Blue1, bold = true};
-      [7] = {background = Screen.colors.Plum1, foreground = Screen.colors.Magenta};
-    }}
+      screen:expect{grid=[[
+        {1:impl}{2: Foo                      }|
+        {2:    }{1:fn}{2: }{3:bar}{2:(}{7:&}{10:self}{2:) {           }|
+        {2:        }{1:if}{2: condition {        }|
+        {2:            }{1:for}{2: i }{1:in}{2: }{10:0}{2:..}{10:100}{2: { }|
+                                      |
+        ^            }                 |
+                }                     |
+            }                         |
+        }                             |
+                                      |
+        {4:struct} {5:Foo} {                  |
+                                      |
+            active: {9:bool},             |
+                                      |
+            username: {9:String},         |
+                                      |
+      ]]}
+
+      feed'14<C-e>'
+      screen:expect{grid=[[
+        {1:struct}{2: }{3:Foo}{2: {                  }|
+                                      |
+            email: {9:String},            |
+                                      |
+            sign_in_count: {9:u64},       |
+        ^                              |
+        }                             |
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+                                      |
+      ]]}
+
+    end)
+
+    it('c', function()
+      cmd('edit test/test.c')
+      feed'<C-e>'
+
+      -- Check the struct context
+      screen:expect{grid=[[
+        {7:struct}{2: Bert {                 }|
+            {8:// comment}                |
+            {9:int} *f2;                  |
+            {8:// comment}                |
+            {8:// comment}                |
+        ^    {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+        };                            |
+                                      |
+        {9:typedef} {9:enum} {                |
+          E1,                         |
+          E2,                         |
+          E3                          |
+          {8:// comment}                  |
+                                      |
+      ]]}
+
+      feed'12<C-e>'
+
+      -- Check the enum context
+      screen:expect{grid=[[
+        {7:typedef}{2: }{7:enum}{2: {                }|
+          E3                          |
+          {8:// comment}                  |
+          {8:// comment}                  |
+          {8:// comment}                  |
+        ^  {8:// comment}                  |
+          {8:// comment}                  |
+          {8:// comment}                  |
+        } Myenum;                     |
+                                      |
+        {9:int} main({9:int} arg1,            |
+                 {9:char} **arg2,         |
+                 {9:char} **arg3          |
+                 )                    |
+        {                             |
+                                      |
+      ]]}
+
+      feed'40<C-e>'
+      screen:expect{grid=[[
+        {7:int}{2: main(}{7:int}{2: arg1, }{7:char}{2: **arg2}|
+        {2:  }{1:if}{2: (arg1 == }{10:4}{2: && arg2 == arg}|
+        {2:    }{1:for}{2: (}{7:int}{2: i = }{10:0}{2:; i < arg1; }|
+        {2:      }{1:while}{2: (}{10:1}{2:) {             }|
+              }                       |
+        ^                              |
+              {4:do} {                    |
+                {8:// comment}            |
+                {8:// comment}            |
+                {8:// comment}            |
+                {8:// comment}            |
+                {8:// comment}            |
+                                      |
+              } {4:while} ({11:1});            |
+              {8:// comment}              |
+                                      |
+      ]]}
+    end)
+
+    it('typescript', function()
+      cmd('edit test/test.ts')
+      feed'<C-e>'
+
+      screen:expect{grid=[[
+        {1:interface}{2: }{3:User}{2: }{3:{}{2:              }|
+                                      |
+                                      |
+                                      |
+          {5:id}: {9:number}{4:;}                 |
+        ^                              |
+                                      |
+                                      |
+                                      |
+        {5:}}                             |
+                                      |
+        {4:class} UserAccount {5:{}           |
+          {5:name}: {9:string};               |
+          {5:id}: {9:number};                 |
+                                      |
+                                      |
+      ]]}
+
+      feed'21<C-e>'
+      screen:expect{grid=[[
+        {1:class}{2: UserAccount }{3:{}{2:           }|
+        {2:  }{3:constructor}{2:(}{12:name}{2::}{12: }{7:string}{1:,}{12: id}|
+        {2:    }{1:for}{2: (}{3:let}{2: i = }{10:0}{1:;}{2: i < }{10:3}{1:;}{2: i++}|
+                                      |
+                                      |
+        ^                              |
+            {5:}}                         |
+                                      |
+                                      |
+                                      |
+                                      |
+          {5:}}                           |
+        {5:}}                             |
+                                      |
+                                      |
+                                      |
+      ]]}
+
+      feed'16<C-e>'
+      screen:expect{grid=[[
+        {1:function}{2: }{3:wrapInArray}{2:(}{12:obj}{2::}{12: }{7:stri}|
+        {2:  }{1:if}{2: (}{3:typeof}{2: obj === }{10:"string"}{2:)}|
+                                      |
+                                      |
+                                      |
+        ^                              |
+          {5:}}                           |
+          {4:return} obj;                 |
+        {5:}}                             |
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+                                      |
+      ]]}
+    end)
+
   end)
+
 end)


### PR DESCRIPTION
Re adds the default patterns from https://github.com/nvim-treesitter/nvim-treesitter-context/pull/156.

Terraform uses `block`s for all their top level data structures. Ideally I'd add a query for those that have an identifier that starts with `resource`, `data`, `locals` or `provider`. But i need some advice on how to do this.
